### PR TITLE
chore: add new languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <label for="language">Language</label>
       <select
         id="language"
-        x-data="{ langs: { 'Bash': 'bash.sh', 'CoffeeScript': 'coffeescript.coffee', 'C++': 'cpp.cpp', 'CSS': 'css.css', 'Go': 'go.go', 'Haskell': 'haskell.hs', 'HTML': 'html.html', 'Java': 'java.java', 'JavaScript': 'javascript.js', 'JSON': 'json.json', 'Kotlin': 'kotlin.kt', 'Lua': 'lua.lua', 'Markdown': 'markdown.md', 'Python': 'python.py', 'Rust': 'rust.rs', 'Scala': 'scala.scala', 'SQL': 'sql.sql', 'TOML': 'toml.toml', 'TypeScript': 'typescript.ts', 'YAML': 'yaml.yaml' } }"
+        x-data="{ langs: { 'AsciiDoc': 'asciidoc.adoc', 'Bash': 'bash.sh', 'CoffeeScript': 'coffeescript.coffee', 'C++': 'cpp.cpp', 'C#': 'cs.cs', 'CSS': 'css.css', 'Dart': 'dart.dart', 'Diff': 'diff.diff', 'Go': 'go.go', 'Haskell': 'haskell.hs', 'HTML': 'html.html', 'Java': 'java.java', 'JavaScript': 'javascript.js', 'JSON': 'json.json', 'JSX': 'jsx.jsx', 'Kotlin': 'kotlin.kt', 'Lua': 'lua.lua', 'Makefile': 'Makefile', 'Markdown': 'markdown.md', 'Nix': 'nix.nix', 'PHP': 'php.php', 'Python': 'python.py', 'Rust': 'rust.rs', 'Scala': 'scala.scala', 'SQL': 'sql.sql', 'TOML': 'toml.toml', 'TSX': 'tsx.tsx', 'TypeScript': 'typescript.ts', 'YAML': 'yaml.yaml' } }"
         x-model="language"
         x-on:change="changeSample()"
         x-init="changeSample()"


### PR DESCRIPTION
This PR adds the languages that were missing, easier to check if highlighting works as expected or not. Some languages are [not supported](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md) by highlight.js or require an additional library, so haven't added these languages.