### PR TITLE
fix: remove hljs generated aliases when switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
       .then(res => res.text())
       .then(text => {
         $refs.sample.innerHTML = encode(text);
+        const classNames = $refs.sample.className.split(' hljs ');
+        if (classNames.length == 2) {
+          $refs.sample.className = `hljs ${classNames[1]}`;
+        }
         $nextTick(() => hljs.highlightElement($refs.sample));
       });
   }


### PR DESCRIPTION
When switching to some languages we can see highlight.js adding other classes automatically to match, for example switching to HTML will add the `language-html` **and** `language-xml` classes. However, when switching back to a language like Rust, it will keep the `language-xml` in front of all classes, and have the normal `language-rs` class at the end.
That results in wrong highlighting.

Switching from Rust to HTML to Rust results in the following:


| Before | After |
|--------|--------|
| ![Before](https://github.com/catppuccin/highlightjs/assets/43011723/ae834625-0d10-4f15-bb92-bbffa2d14acb) | ![After](https://github.com/catppuccin/highlightjs/assets/43011723/c4dc89a0-006b-454d-b008-7cf3bd0f93bd) |
| **Classes:** `language-xml hljs block rounded-md p-4 language-rust` | **Classes:** `hljs block rounded-md p-4 language-rust` | 