### PR TITLE
fix(preview): nix syntax highlighting

### DIFF
--- a/preview/index.html
+++ b/preview/index.html
@@ -47,6 +47,7 @@
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/diff.min.js"></script>
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/haskell.min.js"></script>
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/scala.min.js"></script>
+    <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/nix.min.js"></script>
     <script defer src="//cdn.jsdelivr.net/npm/@alpinejs/persist@3.13.0/dist/cdn.min.js"></script>
     <script defer src="//cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/cdn.min.js"></script>
     <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
Nix syntax highlighting is currently broken on the preview since the language definition isn't imported.