### PR TITLE
fix(preview): load asciidoc grammar

### DIFF
--- a/preview/index.html
+++ b/preview/index.html
@@ -48,6 +48,7 @@
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/haskell.min.js"></script>
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/scala.min.js"></script>
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/nix.min.js"></script>
+    <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/asciidoc.min.js"></script>
     <script defer src="//cdn.jsdelivr.net/npm/@alpinejs/persist@3.13.0/dist/cdn.min.js"></script>
     <script defer src="//cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/cdn.min.js"></script>
     <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
You can view the url https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/languages/asciidoc.min.js to confirm that it is a working link to a grammar.